### PR TITLE
fixed possible race condition and improved rng

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Tracy-Tzu
+Copyright (c) 2025 Haven F.C. Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ package main
 
 import(
 	"fmt"
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_768"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_768"
 )
 
 func main(){

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/HavenOfTheRaven/kyber-go-native
 
-go 1.20
+go 1.23.0
 
-require golang.org/x/crypto v0.10.0
+toolchain go1.24.3
 
-require golang.org/x/sys v0.9.0 // indirect
+require golang.org/x/crypto v0.38.0
+
+require golang.org/x/sys v0.33.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Tracy-Tzu/kyber-go-native
+module github.com/HavenOfTheRaven/kyber-go-native
 
 go 1.20
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
-golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
-golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
-golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/kyber_1024/kyber_1024.go
+++ b/kyber_1024/kyber_1024.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to implement kyber_1024 and kyber_1024_90s
 package kyber_1024
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"golang.org/x/crypto/sha3"
 	"crypto/aes"
 	"crypto/sha256"

--- a/kyber_1024/kyber_1024_test.go
+++ b/kyber_1024/kyber_1024_test.go
@@ -16,6 +16,7 @@ import(
 
 func Test_kyber1024(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber1024-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)
@@ -54,6 +55,7 @@ func Test_kyber1024(t *testing.T){
 
 func Test_kyber1024_90s(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber1024_90s-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)

--- a/kyber_1024/kyber_1024_test.go
+++ b/kyber_1024/kyber_1024_test.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to run tests and benchmarks on kyber_1024 and kyber_1024
 package kyber_1024
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"testing"
 	"os"
 )

--- a/kyber_512/kyber_512.go
+++ b/kyber_512/kyber_512.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to implement kyber_512 and kyber_512_90s
 package kyber_512
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"golang.org/x/crypto/sha3"
 	"crypto/aes"
 	"crypto/sha256"

--- a/kyber_512/kyber_512_test.go
+++ b/kyber_512/kyber_512_test.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to run tests and benchmarks on kyber_512 and kyber_512_9
 package kyber_512
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"testing"
 	"os"
 )

--- a/kyber_512/kyber_512_test.go
+++ b/kyber_512/kyber_512_test.go
@@ -16,6 +16,7 @@ import(
 
 func Test_kyber512(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber512-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)
@@ -54,6 +55,7 @@ func Test_kyber512(t *testing.T){
 
 func Test_kyber512_90s(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber512_90s-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)

--- a/kyber_768/kyber_768.go
+++ b/kyber_768/kyber_768.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to implement kyber_768 and kyber_768_90s
 package kyber_768
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"golang.org/x/crypto/sha3"
 	"crypto/aes"
 	"crypto/sha256"

--- a/kyber_768/kyber_768_test.go
+++ b/kyber_768/kyber_768_test.go
@@ -16,6 +16,7 @@ import(
 
 func Test_kyber_768(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber768-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)
@@ -54,6 +55,7 @@ func Test_kyber_768(t *testing.T){
 
 func Test_kyber_768_90s(t *testing.T){
 	var curpos,temp_len uint
+	kyber_ops.Set_test_rand()
 	data,err:=os.ReadFile("kyber768_90s-kat.rsp")
 	if err!=nil{
 		t.Fatal(err)

--- a/kyber_768/kyber_768_test.go
+++ b/kyber_768/kyber_768_test.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:
@@ -9,7 +9,7 @@ This file contains code to run tests and benchmarks on kyber_768 and kyber_768_9
 package kyber_768
 
 import(
-	"github.com/Tracy-Tzu/kyber-go-native/kyber_ops"
+	"github.com/HavenOfTheRaven/kyber-go-native/kyber_ops"
 	"testing"
 	"os"
 )

--- a/kyber_ops/Common.go
+++ b/kyber_ops/Common.go
@@ -42,6 +42,11 @@ func Init_Seed(str string)(err error){
 }
 
 var rng rng_info
+var test_rand bool=false
+
+func Set_test_rand(){
+	test_rand=true
+}
 
 func init_rng(seed *[48]byte){
 	rng.iv=[16]byte{}
@@ -50,6 +55,10 @@ func init_rng(seed *[48]byte){
 }
 
 func Read_RNG(rand_data []byte){
+	if !test_rand{
+		rand.Read(rand_data)
+		return
+	}
 	cipher,_:=aes.NewCipher(rng.key[:])
 	length:=len(rand_data)
 	for cur:=0;cur<length;cur+=16{
@@ -77,12 +86,6 @@ func update_rng(addion *[48]byte){
 			I++
 		}
 	}
-}
-
-func init(){
-	var bytes48 [48]byte
-	rand.Read(bytes48[:])
-	init_rng(&bytes48)
 }
 
 func CBD2(B *[128]byte,f *[256]int16){
@@ -318,7 +321,7 @@ func CSUBQ_vec[v vec](f v){
 }
 
 func aes_count(iv *[16]byte){
-	for i:=15;i>0;i--{
+	for i:=15;i>=0;i--{
 		iv[i]++
 		if iv[i]>0{
 			break

--- a/kyber_ops/Common.go
+++ b/kyber_ops/Common.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:

--- a/kyber_ops/Encoding.go
+++ b/kyber_ops/Encoding.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:

--- a/kyber_ops/tests.go
+++ b/kyber_ops/tests.go
@@ -1,4 +1,4 @@
-/*Copyright (c) 2023 Tracy-Tzu under the MIT license
+/*Copyright (c) 2025 Haven F.C. Johnson under the MIT license
 The kyber algorithm has a license that can be found in the file titled "nist-pqc-license-summary-and-excerpts.pdf"
 
 Go port of the kyber post quantum encryption algorithm laid out by the NIST round 3 package that can be found by following the link below:


### PR DESCRIPTION
The current system of using a global variable to store rng can cause possible race conditions when using multiple threads creating a venerability. 